### PR TITLE
Add put/delete functions to auth and audit

### DIFF
--- a/eg/example.pl
+++ b/eg/example.pl
@@ -12,11 +12,12 @@ use lib 'lib';
 
 use WebService::HashiCorp::Vault;
 
-my $vault = WebService::HashiCorp::Vault->new(
-    token => 'hvs.k2Kcx2LWi6N1K71C2Q7mC6td'
-);
+my $TOKEN = $ENV{VAULT_ROOT_TOKEN_ID};
+die "Please set your root token" if ! $TOKEN;
 
-# print Dumper $vault;
+my $vault = WebService::HashiCorp::Vault->new(token => $TOKEN);
+
+die "Couldn't open vault" if !$vault;
 
 my $sys = $vault->sys;
 

--- a/eg/example.pl
+++ b/eg/example.pl
@@ -8,19 +8,73 @@ use Data::Dumper;
 $Data::Dumper::Indent = 1;
 $Data::Dumper::Sortkeys = 1;
 
-# use lib 'lib';
+use lib 'lib';
 
 use WebService::HashiCorp::Vault;
 
 my $vault = WebService::HashiCorp::Vault->new(
-    token => '94257c2a-a475-a301-cd33-2ead770de31b'
+    token => 'hvs.k2Kcx2LWi6N1K71C2Q7mC6td'
 );
 
 # print Dumper $vault;
 
-# my $sys = $vault->sys;
+my $sys = $vault->sys;
 
-# p $sys->mounts;
+my $audits = $sys->audit;
+my @keys;
+for my $key (keys %{$audits->{data}}) {
+    next if $key eq 'audit_name/';
+    $key =~ s!\/$!!;
+    push @keys, $key;
+}
+
+if (!$audits->{data}{"goat/"}) {
+    print "About to add audit goat\n";
+    $sys->audit_put('goat', type => 'file', options => {file_path  => '/tmp/goat'});
+}
+
+
+$audits = $sys->audit;
+
+if ($audits->{data}{"goat/"}) {
+    print "Either we added goat or it was there already\n";
+}
+
+$sys->audit_del('goat');
+
+$audits = $sys->audit;
+
+if (!$audits->{data}{"goat/"}) {
+    print   " Deleted goat\n";
+}
+my $auths = $sys->auth;
+
+for my $key (keys %{$auths->{data}}) {
+    next if $key eq 'auth_name/';
+    $key =~ s!\/$!!;
+    push @keys, $key;
+}
+
+if (!$auths->{data}{"goat/"}) {
+    print "About to add auth goat\n";
+    $sys->auth_put('goat', type => 'file', options => {file_path  => '/tmp/goat'});
+}
+
+
+$auths = $sys->auth;
+
+if ($auths->{data}{"goat/"}) {
+    print "Either we added goat or it was there already\n";
+}
+
+$sys->auth_del('goat');
+
+$auths = $sys->auth;
+
+if (!$auths->{data}{"goat/"}) {
+    print   " Deleted goat\n";
+}
+
 
 my $cubby = $vault->secret( backend => 'cubbyhole', path => 'cubbyhole' );
 

--- a/lib/WebService/HashiCorp/Vault/Sys.pm
+++ b/lib/WebService/HashiCorp/Vault/Sys.pm
@@ -11,7 +11,6 @@ package WebService::HashiCorp::Vault::Sys;
 use Moo;
 # VERSION
 use namespace::clean;
-
 extends 'WebService::HashiCorp::Vault::Base';
 
 has '+mount' => ( is => 'ro', default => 'sys' );
@@ -47,14 +46,43 @@ Returns the 'audit' of the vault from API location I</sys/audit>
 
 The result is a hash reference
 
-TODO: implement PUT and DELETE audit with this function
-
 =cut
 
 sub audit {
     my $self = shift;
     return $self->get( $self->_mkuri('audit') )
 }
+
+=head2 audit_put
+
+ my $audit = $sys->audit($audit_device, %options);
+
+Add an audit device.
+Returns true (1) if it succeeds, false (0) other wise.
+
+=cut
+
+sub audit_put {
+    my ( $self, $name, %params ) = @_;
+    return $self-_sys_put( 'audit', $name, %params );
+
+}
+
+
+=head2 audit_del
+
+ my $audit = $sys->auth_del($audit_device);
+
+Delete an audit device.
+
+=cut
+
+sub audit_del {
+    my ( $self, $name ) = @_;
+    return $self-_sys_del( 'audit', $name );
+}
+
+
 
 #            <a href="/api/system/audit-hash.html"><tt>/sys/audit-hash</tt></a>
 #
@@ -67,16 +95,61 @@ sub audit {
 
 Returns the 'auth' of the vault from API location I</sys/auth>
 
-The result is a hash reference
+The result is a hash reference 
 
-TODO: implement POST and DELETE auth with this function
 
 =cut
 
 sub auth {
     my $self = shift;
-    return $self->get( $self->_mkuri('auth') )
+    return $self->get( $self->_mkuri('auth') );
 }
+
+=head2 auth_put
+
+ my $audit = $sys->auth($auth_method, %options);
+
+Add an Auth method
+Returns true (1) if it succeeds, false (0) other wise.
+
+=cut
+
+sub auth_put {
+    my ( $self, $name, %params ) = @_;
+    return $self-_sys_put( 'audit', $name, %params );
+
+}
+
+=head2 auth_del
+
+ my $audit = $sys->auth_del($audit_device);
+
+Delete an auth method.
+
+=cut
+
+sub auth_del {
+    my ( $self, $name ) = @_;
+    return $self-_sys_del( 'audit', $name );
+}
+
+#
+# Internal functions to do the put/del actions.
+#
+sub _sys_put {
+    my ( $self, $sys_type, $name, %params ) = @_;
+    my $uri = join '/', $self->_mkuri($sys_type), $name;
+    return $self->post( $uri, \%params );
+
+}
+
+sub _sys_del {
+    my ( $self, $sys_type, $name ) = @_;
+    my $uri = join '/', $self->_mkuri($sys_type), $name;
+    return $self->delete( $uri );
+
+}
+
 
 #            <a href="/api/system/capabilities.html"><tt>/sys/capabilities</tt></a>
 #
@@ -91,7 +164,6 @@ sub auth {
 #
 #
 #            <a href="/api/system/generate-root.html"><tt>/sys/generate-root</tt></a>
-
 =head2 generate_root
 
  my $generate-root = $sys->generate-root();

--- a/lib/WebService/HashiCorp/Vault/Sys.pm
+++ b/lib/WebService/HashiCorp/Vault/Sys.pm
@@ -64,7 +64,7 @@ Returns true (1) if it succeeds, false (0) other wise.
 
 sub audit_put {
     my ( $self, $name, %params ) = @_;
-    return $self-_sys_put( 'audit', $name, %params );
+    return $self->_sys_put( 'audit', $name, %params );
 
 }
 
@@ -79,7 +79,7 @@ Delete an audit device.
 
 sub audit_del {
     my ( $self, $name ) = @_;
-    return $self-_sys_del( 'audit', $name );
+    return $self->_sys_del( 'audit', $name );
 }
 
 
@@ -116,7 +116,7 @@ Returns true (1) if it succeeds, false (0) other wise.
 
 sub auth_put {
     my ( $self, $name, %params ) = @_;
-    return $self-_sys_put( 'audit', $name, %params );
+    return $self->_sys_put( 'audit', $name, %params );
 
 }
 
@@ -130,7 +130,7 @@ Delete an auth method.
 
 sub auth_del {
     my ( $self, $name ) = @_;
-    return $self-_sys_del( 'audit', $name );
+    return $self->_sys_del( 'audit', $name );
 }
 
 #


### PR DESCRIPTION
This a result of the Pull Request Club. A small step on the way. I can see lots of other stuff to do but I have confined myself to just adding put and delete functions to auth and audit. I chose 'put' rather that 'post' as the former seems closer to the REST idea, though the API spec says that they are equivalent - at least for now (both work). 